### PR TITLE
Remove numpy from PEP 518 build deps

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "cscore_src"]
 	path = cscore_src
 	url = https://github.com/robotpy/cscore.git
+[submodule "pybind11"]
+	path = pybind11
+	url = https://github.com/pybind/pybind11.git
+	branch = v2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
     - docker run $IMAGE pip --version
     script:
     - python setup.py sdist
-    - docker run --mount type=bind,source="$(pwd)"/dist,target=/dist $IMAGE /bin/sh -c "pip install setuptools pybind11 && pip install --no-build-isolation -v /$(echo dist/*.tar.gz) && python3 -m cscore --help"
+    - docker run --mount type=bind,source="$(pwd)"/dist,target=/dist $IMAGE /bin/sh -c "pip install -v /$(echo dist/*.tar.gz) && python3 -m cscore --help"
 
   - stage: format-check
     python:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ include cscore_src/cscore/src/main/native/include/*.inl
 recursive-include cscore_src/wpiutil/src/main/native/cpp *.h *.inc
 recursive-include cscore_src/wpiutil/src/main/native/include *.h *.inl *.inc
 recursive-include cscore_src/wpiutil/src/main/native/libuv *.h
+recursive-include pybind11/include *.h

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,20 @@
 [build-system]
-requires = ["setuptools", "wheel", "pybind11>=2.2"]
+requires = ["setuptools", "wheel"]
+
+[tool.black]
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+
+  | pybind11
+)/
+'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "pybind11>=2.2"]
+requires = ["setuptools", "wheel", "pybind11>=2.2"]

--- a/setup.py
+++ b/setup.py
@@ -61,22 +61,6 @@ with open(join(setup_dir, "README.rst"), "r") as readme_file:
 #
 
 
-class get_pybind_include(object):
-    """Helper class to determine the pybind11 include path
-
-    The purpose of this class is to postpone importing pybind11
-    until it is actually installed, so that the ``get_include()``
-    method can be invoked. """
-
-    def __init__(self, user=False):
-        self.user = user
-
-    def __str__(self):
-        import pybind11
-
-        return pybind11.get_include(self.user)
-
-
 class get_numpy_include(object):
     def __str__(self):
         import numpy as np
@@ -229,9 +213,7 @@ ext_modules = [
         + list(recursive_glob("cscore_src/wpiutil/src/main/native/cpp"))
         + get_libuv_sources("cscore_src/wpiutil/src/main/native/libuv"),
         include_dirs=[
-            # Path to pybind11 headers
-            get_pybind_include(),
-            get_pybind_include(user=True),
+            "pybind11/include",
             "cscore_src/cscore/src/main/native/include",
             "cscore_src/cscore/src/main/native/cpp",
             "cscore_src/wpiutil/src/main/native/include",
@@ -259,7 +241,7 @@ setup(
     long_description=long_description,
     packages=find_packages(),
     ext_modules=ext_modules,
-    setup_requires=["numpy", "pybind11>=2.2"],
+    setup_requires=["numpy"],
     install_requires=["numpy", "pynetworktables"],
     license="BSD",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -241,7 +241,6 @@ setup(
     long_description=long_description,
     packages=find_packages(),
     ext_modules=ext_modules,
-    setup_requires=["numpy"],
     install_requires=["numpy", "pynetworktables"],
     license="BSD",
     zip_safe=False,


### PR DESCRIPTION
We assume OpenCV has been installed with the Python 3 bindings, so this
should be a safe assumption I guess.

We should test the typical user's install flow.