### PR TITLE
Make pynetworktables an optional dependency

### DIFF
--- a/cscore/__main__.py
+++ b/cscore/__main__.py
@@ -8,7 +8,10 @@ import stat
 import sys
 import threading
 
-from networktables import NetworkTables
+try:
+    from networktables import NetworkTables
+except ImportError:
+    NetworkTables = None
 
 log_datefmt = "%H:%M:%S"
 log_format = "%(asctime)s:%(msecs)03d %(levelname)-8s: %(name)-20s: %(message)s"
@@ -70,10 +73,15 @@ def main():
     logger = logging.getLogger("cscore")
 
     # Initialize NetworkTables next
-    if args.team:
-        NetworkTables.startClientTeam(args.team)
+    if NetworkTables is not None:
+        if args.team:
+            NetworkTables.startClientTeam(args.team)
+        else:
+            NetworkTables.initialize(server=args.robot)
     else:
-        NetworkTables.initialize(server=args.robot)
+        logger.warning(
+            "pynetworktables is not installed, skipping NetworkTables initialization."
+        )
 
     # If stdin is a pipe, then die when the pipe goes away
     # -> this allows us to detect if a parent process exits

--- a/cscore/cameraserver.py
+++ b/cscore/cameraserver.py
@@ -16,8 +16,6 @@ import logging
 
 logger = logging.getLogger("cscore.cserver")
 
-from networktables import NetworkTables
-
 __all__ = ["CameraServer", "VideoException"]
 
 
@@ -225,6 +223,8 @@ class CameraServer:
                 entry.setString(event.valueStr)
 
     def __init__(self):
+        from networktables import NetworkTables
+
         self._mutex = threading.RLock()
 
         self._defaultUsbDevice = 0  # note: atomic upstream, keep accesses thread-safe

--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,6 @@ def get_cscore_sources(d):
         l.extend(glob.glob(d + "/osx/*.cpp"))
     else:
         l.extend(glob.glob(d + "/linux/*.cpp"))
-    print(l)
     return l
 
 
@@ -260,7 +259,8 @@ setup(
     packages=find_packages(),
     ext_modules=ext_modules,
     setup_requires=["numpy", "pybind11>=2.2"],
-    install_requires=["numpy", "pynetworktables"],
+    install_requires=["numpy"],
+    extras_require={"cameraserver": ["pynetworktables>=2018.0"]},
     license="BSD",
     zip_safe=False,
     cmdclass={"build_ext": BuildExt},


### PR DESCRIPTION
This moves the pynetworktables dependency to an "extra" feature, like so:

```bash
pip install "robotpy-cscore[cameraserver]"
```