### PR TITLE
_cscore: Remove no-argument constructors

### DIFF
--- a/docs/objects.rst
+++ b/docs/objects.rst
@@ -36,18 +36,12 @@ AxisCamera
 CvSink
 ------
 
-.. py:class:: CvSink(*args, **kwargs)
+.. py:class:: CvSink(name: str) -> None
    :module: cscore
 
    Bases: :class:`cscore.VideoSink`
 
    A sink for user code to accept video frames as OpenCV images.
-   
-   Overloaded function.
-   
-   1. __init__() -> None
-   
-   2. __init__(name: str) -> None
    
    Create a sink for accepting OpenCV images. :meth:`grabFrame` must be called on the created sink to get each new image
    
@@ -107,16 +101,14 @@ CvSource
    
    Overloaded function.
    
-   1. __init__() -> None
-   
-   2. __init__(name: str, mode: cscore.VideoMode) -> None
+   1. __init__(name: str, mode: cscore.VideoMode) -> None
    
    Create an OpenCV source.
    
    :param name: Source name (arbitrary unique identifier)
    :param mode: Video mode being generated
    
-   3. __init__(name: str, pixelFormat: cscore.VideoMode.PixelFormat, width: int, height: int, fps: int) -> None
+   2. __init__(name: str, pixelFormat: cscore.VideoMode.PixelFormat, width: int, height: int, fps: int) -> None
    
    Create an OpenCV source.
    
@@ -307,9 +299,7 @@ MjpegServer
    
    Overloaded function.
    
-   1. __init__() -> None
-   
-   2. __init__(name: str, listenAddress: str, port: int) -> None
+   1. __init__(name: str, listenAddress: str, port: int) -> None
    
    Create a MJPEG-over-HTTP server sink.
    
@@ -317,7 +307,7 @@ MjpegServer
    :param listenAddress: TCP listen address (empty string for all addresses)
    :param port: TCP port number
    
-   3. __init__(name: str, port: int) -> None
+   2. __init__(name: str, port: int) -> None
    
    Create a MJPEG-over-HTTP server sink.
    
@@ -506,16 +496,14 @@ UsbCamera
    
    Overloaded function.
    
-   1. __init__() -> None
-   
-   2. __init__(name: str, dev: int) -> None
+   1. __init__(name: str, dev: int) -> None
    
    Create a source for a USB camera based on device number.
    
    :param name: Source name (arbitrary unique identifier)
    :param dev: Device number (e.g. 0 for ``/dev/video0``)
    
-   3. __init__(name: str, path: str) -> None
+   2. __init__(name: str, path: str) -> None
    
    Create a source for a USB camera based on device path.
    
@@ -579,7 +567,7 @@ UsbCameraInfo
 VideoCamera
 -----------
 
-.. py:class:: VideoCamera() -> None
+.. py:class:: VideoCamera
    :module: cscore
 
    Bases: :class:`cscore.VideoSource`
@@ -708,18 +696,12 @@ VideoListener
 VideoMode
 ---------
 
-.. py:class:: VideoMode(*args, **kwargs)
+.. py:class:: VideoMode(pixelFormat: cscore.VideoMode.PixelFormat, width: int, height: int, fps: int) -> None
    :module: cscore
 
    Bases: :class:`cscore._CS_VideoMode`
 
    Video mode
-   
-   Overloaded function.
-   
-   1. __init__() -> None
-   
-   2. __init__(pixelFormat: cscore.VideoMode.PixelFormat, width: int, height: int, fps: int) -> None
    
    
    .. py:class:: VideoMode.PixelFormat(arg0: int) -> None
@@ -777,7 +759,7 @@ VideoMode
 VideoProperty
 -------------
 
-.. py:class:: VideoProperty() -> None
+.. py:class:: VideoProperty
    :module: cscore
 
    A source or sink property.
@@ -879,16 +861,10 @@ VideoProperty
 VideoSink
 ---------
 
-.. py:class:: VideoSink(*args, **kwargs)
+.. py:class:: VideoSink(sink: cscore.VideoSink) -> None
    :module: cscore
 
    A sink for video that accepts a sequence of frames.
-   
-   Overloaded function.
-   
-   1. __init__() -> None
-   
-   2. __init__(sink: cscore.VideoSink) -> None
    
    
    .. py:class:: VideoSink.Kind(arg0: int) -> None
@@ -1015,16 +991,10 @@ VideoSink
 VideoSource
 -----------
 
-.. py:class:: VideoSource(*args, **kwargs)
+.. py:class:: VideoSource(source: cscore.VideoSource) -> None
    :module: cscore
 
    A source for video that provides a sequence of frames.
-   
-   Overloaded function.
-   
-   1. __init__() -> None
-   
-   2. __init__(source: cscore.VideoSource) -> None
    
    
    .. py:class:: VideoSource.ConnectionStrategy(arg0: int) -> None

--- a/src/_cscore.cpp
+++ b/src/_cscore.cpp
@@ -69,7 +69,6 @@ PYBIND11_MODULE(_cscore, m) {
     py::class_<VideoMode, CS_VideoMode> videomode(m, "VideoMode");
     videomode.doc() = "Video mode";
     videomode
-      .def(py::init<>())
       .def(py::init<cs::VideoMode::PixelFormat, int, int, int>(),
            py::arg("pixelFormat"), py::arg("width"), py::arg("height"), py::arg("fps"))
       .def_property("pixelFormat",
@@ -109,7 +108,6 @@ PYBIND11_MODULE(_cscore, m) {
     py::class_<VideoProperty> videoproperty(m, "VideoProperty");
     videoproperty.doc() = "A source or sink property.";
     videoproperty
-      .def(py::init<>())
       .def("getName", &VideoProperty::GetName, release_gil())
       .def("getKind", &VideoProperty::GetKind)
       .def("isBoolean", &VideoProperty::IsBoolean)
@@ -142,7 +140,6 @@ PYBIND11_MODULE(_cscore, m) {
     py::class_<VideoSource> videosource(m, "VideoSource");
     videosource.doc() = "A source for video that provides a sequence of frames.";
     videosource
-      .def(py::init<>())
       .def(py::init<cs::VideoSource>(), py::arg("source"))
       .def("getHandle", &VideoSource::GetHandle)
       .def(py::self == py::self)
@@ -244,7 +241,6 @@ PYBIND11_MODULE(_cscore, m) {
     py::class_<VideoCamera, VideoSource> videocamera(m, "VideoCamera");
     videocamera.doc() = "A source that represents a video camera.";
     videocamera
-      .def(py::init<>())
       .def("setBrightness", &VideoCamera::SetBrightness, release_gil(),
            py::arg("brightness"),
            "Set the brightness, as a percentage (0-100).")
@@ -275,8 +271,7 @@ PYBIND11_MODULE(_cscore, m) {
     py::class_<UsbCamera, VideoCamera> usbcamera(m, "UsbCamera");
     usbcamera.doc() = "A source that represents a USB camera.";
     usbcamera
-      .def(py::init<>())
-      .def(py::init<const wpi::Twine&,int>(),
+      .def(py::init<const wpi::Twine&, int>(),
           py::arg("name"), py::arg("dev"),
           "Create a source for a USB camera based on device number.\n\n"
           ":param name: Source name (arbitrary unique identifier)\n"
@@ -354,7 +349,6 @@ PYBIND11_MODULE(_cscore, m) {
     py::class_<CvSource, VideoSource> cvsource(m, "CvSource");
     cvsource.doc() = "A source for user code to provide OpenCV images as video frames.";
     cvsource
-      .def(py::init<>())
       .def(py::init<const wpi::Twine&, VideoMode>(),
           py::arg("name"), py::arg("mode"),
           "Create an OpenCV source.\n\n"
@@ -435,7 +429,6 @@ PYBIND11_MODULE(_cscore, m) {
     py::class_<VideoSink> videosink(m, "VideoSink");
     videosink.doc() = "A sink for video that accepts a sequence of frames.";
     videosink
-      .def(py::init<>())
       .def(py::init<cs::VideoSink>(), py::arg("sink"))
       .def("getHandle", &VideoSink::GetHandle)
       .def(py::self == py::self)
@@ -499,7 +492,6 @@ PYBIND11_MODULE(_cscore, m) {
     py::class_<MjpegServer, VideoSink> mjpegserver(m, "MjpegServer");
     mjpegserver.doc() = "A sink that acts as a MJPEG-over-HTTP network server.";
     mjpegserver
-      .def(py::init<>())
       .def(py::init<const wpi::Twine&, const wpi::Twine&, int>(),
           py::arg("name"), py::arg("listenAddress"), py::arg("port"),
           "Create a MJPEG-over-HTTP server sink.\n\n"
@@ -542,7 +534,6 @@ PYBIND11_MODULE(_cscore, m) {
     py::class_<CvSink, VideoSink> cvsink(m, "CvSink");
     cvsink.doc() = "A sink for user code to accept video frames as OpenCV images.";
     cvsink
-      .def(py::init<>())
       .def(py::init<const wpi::Twine&>(),
           py::arg("name"),
           "Create a sink for accepting OpenCV images. "


### PR DESCRIPTION
These all initialize the object with an invalid handle, so they are not
terribly useful from Python code.

Ref: #60