### PR TITLE
Exclude JNI and PortForwarder with prejudice

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,8 +2,11 @@ include LICENSE
 exclude pyproject.toml
 recursive-include src *.h *.hpp
 recursive-include cscore_src/cscore/src/main/native *.cpp *.h
+exclude cscore_src/cscore/src/main/native/cpp/jni/CameraServerJNI.cpp
 include cscore_src/cscore/src/main/native/include/*.inc
 recursive-include cscore_src/wpiutil/src/main/native *.cpp *.h
+exclude cscore_src/wpiutil/src/main/native/cpp/jni/WPIUtilJNI.cpp
+exclude cscore_src/wpiutil/src/main/native/cpp/PortForwarder.cpp
 recursive-include cscore_src/wpiutil/src/main/native/include *.hpp *.inc
 recursive-include pybind11/include *.h
 include pybind11/LICENSE

--- a/setup.py
+++ b/setup.py
@@ -312,7 +312,7 @@ def get_wpiutil_sources(d):
     if external_wpiutil:
         return []
 
-    jni = re.compile(r"[\/]jni[\/]")
+    jni = re.compile(r"[\\/]jni[\\/]")
     l = [f for f in recursive_glob(d + "/cpp") if not jni.search(f)]
     if sys.platform == "win32":
         l.extend(glob.glob(d + "/windows/*.cpp"))


### PR DESCRIPTION
- Fixes the JNI path regex
- Also exclude them in the manifest
- Also exclude unnecessary PortForwarder to avoid MSVC C++20 errors

See also: https://github.com/conda-forge/robotpy-cscore-feedstock/pull/7